### PR TITLE
feat: add sitemap.xml to Angular build assets configuration

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -25,7 +25,12 @@
             "inlineStyleLanguage": "scss",
             "assets": [
               "src/favicon.ico",
-              "src/assets"
+              "src/assets",
+              {
+                "glob": "sitemap.xml",
+                "input": "src/assets",
+                "output": "/"
+              }
             ],
             "styles": [
               "src/styles.scss"


### PR DESCRIPTION
- Ensure sitemap.xml is included in the output for improved SEO and discoverability.